### PR TITLE
Fan-out lambda missing `lastAccess` attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = (event,cfg = {}) => {
 
     // flag as warm
     warm = true
+    lastAccess = Date.now()
 
     // Fan out if concurrency is set higher than 1
     if (concurrency > 1 && !event[config.test]) {


### PR DESCRIPTION
The lastAccess attribute is only set on the child invocations, but not on the original parent, which leads to both `lastAccessed` and `lastAccessedSeconds` fields appearing `null` on warm lambdas