### PR TITLE
Import Lambda directly to minimize the require time

### DIFF
--- a/lib/lambda-service.js
+++ b/lib/lambda-service.js
@@ -6,8 +6,8 @@
  * @license MIT
  */
 
-// Require AWS SDK
-const AWS = require('aws-sdk') // AWS SDK
+// Require the Lambda client
+const Lambda = require('aws-sdk/clients/lambda') // Lambda
 
 // Export
-module.exports = new AWS.Lambda()
+module.exports = new Lambda()


### PR DESCRIPTION
Requiring the whole AWS SDK can take quite a bit of time, by specifying just the Lambda client, only the core of the AWS SDK is loaded plus the Lambda client.