### PR TITLE
feat: add warming of another function by name

### DIFF
--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -175,4 +175,38 @@ describe('Concurrency Tests', function() {
 
   })
 
+  describe('Warm another function', function() {
+
+    it('should have 3 target lambda invocation', function(done) {
+      let warmer = rewire('../index')
+      stub.returns({ promise: () => true })
+
+      let event = { warmer: true, concurrency: 3, targetFuncName: 'vpc-function' }
+      
+      warmer(event, { log:false }).then(out => {
+        expect(stub.callCount).to.equal(3)
+        expect(stub.args[0][0].InvocationType).to.equal('Event')
+        expect(stub.args[1][0].InvocationType).to.equal('Event')
+        expect(stub.args[2][0].InvocationType).to.equal('RequestResponse')
+        expect(out).to.equal(true)
+        done()
+      })
+    })
+
+    it('should have 1 target lambda invocation', function(done) {
+      let warmer = rewire('../index')
+      stub.returns({ promise: () => true })
+
+      let event = { warmer: true, concurrency: 1, targetFuncName: 'vpc-function' }
+      
+      warmer(event, { log:false }).then(out => {
+        expect(stub.callCount).to.equal(1)
+        expect(stub.args[0][0].InvocationType).to.equal('RequestResponse')
+        expect(out).to.equal(true)
+        done()
+      })
+    })
+
+  })
+
 })


### PR DESCRIPTION
currently it is not possible to use the package to set concurrency more than 1 for lambdas in VPC. Option to  use NAT just for warming sounds not reasonable. Current merge allows to use separate function to support concurrent warming for target lambda