### PR TITLE
Change back deprecated `new Buffer` to `Buffer.from`

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ const handleEvent = (event, config) => {
           FunctionName: target,
           InvocationType: i === concurrency ? 'RequestResponse' : 'Event',
           LogType: 'None',
-          Payload: new Buffer(
+          Payload: Buffer.from(
             JSON.stringify({
               [config.flag]: true, // send warmer flag
               __WARMER_INVOCATION__: i, // send invocation number


### PR DESCRIPTION
It looks like the deprecated `new Buffer` accidentally got reintroduced here in v1.3.0

https://github.com/jeremydaly/lambda-warmer/compare/v1.2.3...v1.3.0#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R90