### PR TITLE
handle multiple non warming events

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ module.exports = (event, cfg = {}) => {
       if (i < event.length) {
         return handleEvent(event[i++], config).then(handleNext)
       }
-      return Promise.resolve(true)
+      return Promise.resolve(event.some((e) => e[config.flag]))
     }
     return handleNext()
   } else {

--- a/test/non-warming-events.js
+++ b/test/non-warming-events.js
@@ -22,6 +22,23 @@ describe('Non-warming Event Tests', function() {
         done()
       })
     })
+
+    it('should return false for list of non warmer events', function(done) {
+      this.slow(500)
+      let warmer = rewire('../index')
+      let event = [{ foo:'bar' }, { foo: 'baz'}]
+
+      let logger = console.log
+      let logData = {}
+      console.log = (log) => { logData = log }
+
+      warmer(event, { log:false }).then(out => {
+        console.log = logger // restore console.log
+        expect(logData).to.deep.equal({})
+        expect(out).to.equal(false)
+        done()
+      })
+    })
   })
 
 })


### PR DESCRIPTION
As an example, implementing a lambda handler for an Appsync batch resolver means handling a list of Appsync resolver events as input for the lambda handler.

Because of the multiple targets feature handling a array of events 

https://github.com/jeremydaly/lambda-warmer/blob/60f2fa290d8c887e9ac1489f80bd0178f668bb8c/index.js#L139

`await warmer(events))`  always resolves to true.

The suggested change makes warmer return true if any event is a warmer event. This should cover most of the cases, since having both warmer events and valid ones in single invocation should not happen.