### PR TITLE
Fix `function` value in logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const handleEvent = (event, config) => {
     // Create log record
     let log = {
       action: 'warmer',
-      function: `${funcName}:${funcVersion}`,
+      function: target,
       id,
       correlationId,
       count: invokeCount,


### PR DESCRIPTION
I noticed that if the target is overwritten then the `function` value in the logs doesn't get updated. I assume this is a bug, and not intentional.

Fixes #63 